### PR TITLE
Fix clientes route component import

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,7 +5,7 @@ import HomeView from '../views/HomeView.vue'
 import ProductosView from '../views/ProductosView.vue'
 import LoginView from '../views/LoginView.vue'
 import ProductoDetalleView from '../views/ProductoDetalleView.vue'
-//import ClientesView from '../views/ClientesView.vue'
+import ClientesView from '../views/ClientesView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -39,8 +39,8 @@ const router = createRouter({
     {
       path: '/clientes',
       name: 'clientes',
-      component: ClienteView,
-    }
+      component: ClientesView,
+    },
   ],
 
   scrollBehavior(to, from, savedPosition) {


### PR DESCRIPTION
## Summary
- import the ClientesView component in the router and use it for the `/clientes` route to prevent runtime errors when mounting the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee60bbb9083228a880599e20081b5